### PR TITLE
Annotation SVG lines were not displaying in front of other elements

### DIFF
--- a/js/src/annotations/osd-region-draw-tool.js
+++ b/js/src/annotations/osd-region-draw-tool.js
@@ -323,11 +323,14 @@
         jQuery.each(shapes, function (index, shape) {
           if (shape.data.annotation['@id'] === annotation['@id']) {
             $.annoUtil.highlightShape(shape);
+            shape.bringToFront();
           } else {
             $.annoUtil.deHighlightShape(shape);
+            shape.sendToBack();
           }
         });
       });
+      this.osdViewer.forceRedraw();
     }
 
   };


### PR DESCRIPTION
Fixing issue where highlighted annotation was not in front of the other elements.
